### PR TITLE
Modify campaign card when the campaign has finished

### DIFF
--- a/app/views/campaigns/_card.html.slim
+++ b/app/views/campaigns/_card.html.slim
@@ -33,8 +33,10 @@
               br
               = "#{number_with_precision(percentage_done, precision: 2, separator: t('application.separator'))} %"
             .col-sm-6.pull-right.text-center
-              = t('campaigns.card.days_left')
-              br
-              = (campaign.deadline.to_date - Time.current.to_date).to_i
-
+              - if campaign.deadline > Time.current
+                = t('campaigns.card.days_left')
+                br
+                  = (campaign.deadline.to_date - Time.current.to_date).to_i
+              - else
+                = t('campaigns.card.finished')
 


### PR DESCRIPTION
## Resumen

- Cuando la campaña había finalizado, en el index de campañas la misma aparecía con tiempo negativo. Se corrigió eso mismo.


### Card de Trello

- https://trello.com/c/ddJ1siYv/27-corregir-el-tiempo-restante-en-la-preview-de-la-campaign