### PR TITLE
the home only shows not finished campaigns

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,8 @@ class ApplicationController < ActionController::Base
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   def index
-    @campaigns = Kaminari.paginate_array(Campaign.limit(4)).page(1).per(4)
+    not_finished_campaigns = Campaign.select { | campaign |  campaign.expired? }.take(4)
+    @campaigns = Kaminari.paginate_array(not_finished_campaigns).page(1).per(4)
   end
 
   def about

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -97,6 +97,10 @@ class Campaign < ActiveRecord::Base
 
   end
 
+  def expired?
+    deadline < Time.now
+  end
+
   private
 
   def funded?


### PR DESCRIPTION
Queria implementarlo utilizando el estado de la campaña para que sea más optimo. Esto sería utilizar :started_not_funded, pero al parecer todas las campañas sin importar que no hayan terminando se encuentran :closed
