### PR TITLE
 fix image in campaign creation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-ruby "2.0.0"
+ruby "2.1.2"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.0.4'

--- a/app/assets/javascripts/campaign_form.js.coffee
+++ b/app/assets/javascripts/campaign_form.js.coffee
@@ -25,3 +25,5 @@ $ ->
 
   $('.upload-button').on 'click', ->
     $('#upload-file-field').click()
+  $('#upload-file-field').change ->
+      $('#inputFile').val(@value)

--- a/app/views/campaigns/new.html.slim
+++ b/app/views/campaigns/new.html.slim
@@ -35,10 +35,12 @@
               span.small-image-text
                 = t('campaigns.new.basic_info.small_image')
               = image_tag 'ayuda.png', class: 'small-image-help'
-            .image-preview.text-center
-              = image_tag @campaign.main_image
+            - if @campaign.main_image.present?
+              .image-preview.text-center
+                = image_tag @campaign.main_image
           .col-md-12.file-field
             #upload-field.text-center
+              input id= "inputFile" readonly=""
               .upload-button.btn
                 = t('campaigns.new.basic_info.choose_image')
               = file_field_tag :main_image, id: 'upload-file-field'


### PR DESCRIPTION
## Summary

It has been added a feedback to notify the user that an image has been uploaded.
Also it has been fixed the broken image in a new campaign creation.
<img width="1276" alt="captura de pantalla 2015-09-13 a las 23 32 54" src="https://cloud.githubusercontent.com/assets/4512091/9840963/f9ee4f30-5a6f-11e5-999b-29faa4442aad.png">
